### PR TITLE
Stop parsing tag values

### DIFF
--- a/lib/xml/document.js
+++ b/lib/xml/document.js
@@ -8,7 +8,7 @@ const parser = new XMLParser({
 	attributeNamePrefix: '',
 	ignoreAttributes: false,
 	ignoreDeclaration: true,
-	parseTagValue: true,
+	parseTagValue: false,
 	preserveOrder: true,
 	trimValues: false,
 	processEntities: { maxTotalExpansions: Infinity }

--- a/test/integration/snapshots/examples/99619ce57a62d070edb7dd912d15399f.json
+++ b/test/integration/snapshots/examples/99619ce57a62d070edb7dd912d15399f.json
@@ -1,0 +1,64 @@
+{
+	"title": "Feed with Numeric Values",
+	"hash": "99619ce57a62d070edb7dd912d15399f",
+	"url": "https://sample-feeds.rowanmanning.com/examples/99619ce57a62d070edb7dd912d15399f/feed.xml",
+	"feed": {
+		"meta": {
+			"type": "rss",
+			"version": "2.0"
+		},
+		"language": null,
+		"title": "t",
+		"description": null,
+		"copyright": null,
+		"url": null,
+		"self": null,
+		"published": null,
+		"updated": null,
+		"generator": null,
+		"image": null,
+		"authors": [],
+		"categories": [],
+		"items": [
+			{
+				"id": null,
+				"title": "007",
+				"description": null,
+				"url": null,
+				"published": null,
+				"updated": null,
+				"content": null,
+				"image": null,
+				"media": [],
+				"authors": [],
+				"categories": []
+			},
+			{
+				"id": null,
+				"title": "0",
+				"description": null,
+				"url": null,
+				"published": null,
+				"updated": null,
+				"content": null,
+				"image": null,
+				"media": [],
+				"authors": [],
+				"categories": []
+			},
+			{
+				"id": "00123",
+				"title": "x",
+				"description": null,
+				"url": null,
+				"published": null,
+				"updated": null,
+				"content": null,
+				"image": null,
+				"media": [],
+				"authors": [],
+				"categories": []
+			}
+		]
+	}
+}

--- a/test/unit/lib/xml/document.test.js
+++ b/test/unit/lib/xml/document.test.js
@@ -28,7 +28,7 @@ describe('lib/xml/document', () => {
 				attributeNamePrefix: '',
 				ignoreAttributes: false,
 				ignoreDeclaration: true,
-				parseTagValue: true,
+				parseTagValue: false,
 				preserveOrder: true,
 				trimValues: false,
 				processEntities: { maxTotalExpansions: Infinity }


### PR DESCRIPTION
As pointed out in #272, parsing the tag values results in some unexpected behaviour when numeric values are encountered in feeds. This resolves the issue by disabling tag value parsing.

Fixes #272.